### PR TITLE
or and operations

### DIFF
--- a/src/dspsim/core.py
+++ b/src/dspsim/core.py
@@ -104,7 +104,14 @@ class FunctionalSimulator:
             imm = s32(imm) if (imm & 0x2000) else imm
             fn(self, rs2, rs1, imm)
             return
-
+        
+            # immediate-only form: imm[23:0] (for jumps, using 14 bits)
+        if argtypes == ('imm',):
+            imm = word & 0x3FFF
+            imm = s32(imm) if (imm & 0x2000) else imm # sign extend
+            fn(self, imm)
+            return
+        
         # HALT / no-arg
         if argtypes == ():
             fn(self)

--- a/src/dspsim/isa.py
+++ b/src/dspsim/isa.py
@@ -1,7 +1,9 @@
 # src/dspsim/isa.py
 # Instruction Set Architecture definitions.
 
-# === Opcode constants (encoding layer) ===
+from .bitutil import s32, u32
+
+# === Opcode constants (The Single Source of Truth) ===
 
 # ALU
 MAJ_ADD   = 0x0
@@ -16,42 +18,56 @@ MAJ_MUL   = 0x8
 MAJ_MAC   = 0x9
 MAJ_NOT   = 0xA
 
-# Memory (using legacy names for assembler compatibility)
-MAJ_LD32  = 0xB
-MAJ_ST32  = 0xC
-MAJ_LD = MAJ_LD32
-MAJ_ST = MAJ_ST32
+# Memory
+MAJ_LD    = 0xB
+MAJ_ST    = 0xC
+MAJ_LD32 = MAJ_LD # Alias for assembler
+MAJ_ST32 = MAJ_ST # Alias for assembler
 
 # Control flow
 MAJ_J     = 0xD
 MAJ_JR    = 0xE
-MAJ_CMPI  = 0xF  # Note: CMPI shares a major opcode with HALT in this simplified model.
-MAJ_HALT  = 0xF  # A sub-opcode would distinguish them in a real ISA.
+MAJ_CMPI  = 0xF # Shares opcode with HALT for this example
+MAJ_HALT  = 0xF
 
 
 # === Functional semantics (executed by simulator) ===
 
 def instr_add(sim, rd, rs1, rs2):
     """R[rd] = R[rs1] + R[rs2]"""
-    sim.regs[rd] = (sim.regs[rs1] + sim.regs[rs2]) & 0xFFFFFFFF
+    sim.regs[rd] = u32(sim.regs[rs1] + sim.regs[rs2])
 
 def instr_addi(sim, rd, rs1, imm):
     """R[rd] = R[rs1] + imm"""
-    sim.regs[rd] = (sim.regs[rs1] + imm) & 0xFFFFFFFF
+    sim.regs[rd] = u32(sim.regs[rs1] + imm)
 
 def instr_sub(sim, rd, rs1, rs2):
     """R[rd] = R[rs1] - R[rs2]"""
-    sim.regs[rd] = (sim.regs[rs1] - sim.regs[rs2]) & 0xFFFFFFFF
+    sim.regs[rd] = u32(sim.regs[rs1] - sim.regs[rs2])
+
+def instr_and(sim, rd, rs1, rs2):
+    """R[rd] = R[rs1] & R[rs2]"""
+    sim.regs[rd] = u32(sim.regs[rs1] & sim.regs[rs2])
+
+def instr_or(sim, rd, rs1, rs2):
+    """R[rd] = R[rs1] | R[rs2]"""
+    sim.regs[rd] = u32(sim.regs[rs1] | sim.regs[rs2])
 
 def instr_ld(sim, rd, rs1, imm):
     """R[rd] = Mem[R[rs1] + imm]"""
-    addr = sim.regs[rs1] + imm
+    addr = u32(sim.regs[rs1] + imm)
     sim.regs[rd] = sim.bus.read32(addr)
 
 def instr_st(sim, rs2, rs1, imm):
     """Mem[R[rs1] + imm] = R[rs2]"""
-    addr = sim.regs[rs1] + imm
+    addr = u32(sim.regs[rs1] + imm)
     sim.bus.write32(addr, sim.regs[rs2])
+
+def instr_j(sim, imm):
+    """PC += signed_offset"""
+    # PC is already advanced to next instruction, so we add the offset.
+    offset = s32(imm << 2)
+    sim.pc += offset
 
 def instr_halt(sim):
     """Stop simulation"""
@@ -64,7 +80,10 @@ INSTRUCTION_SET = {
     'ADD':  (instr_add,  ('reg', 'reg', 'reg'), MAJ_ADD),
     'ADDI': (instr_addi, ('reg', 'reg', 'imm'), MAJ_ADDI),
     'SUB':  (instr_sub,  ('reg', 'reg', 'reg'), MAJ_SUB),
+    'AND':  (instr_and,  ('reg', 'reg', 'reg'), MAJ_AND),
+    'OR':   (instr_or,   ('reg', 'reg', 'reg'), MAJ_OR),
     'LD':   (instr_ld,   ('reg', 'reg', 'imm'), MAJ_LD),
     'ST':   (instr_st,   ('reg', 'reg', 'imm'), MAJ_ST),
+    'J':    (instr_j,    ('imm',),              MAJ_J),
     'HALT': (instr_halt, (),                   MAJ_HALT),
 }

--- a/tests/test_alu_logic.py
+++ b/tests/test_alu_logic.py
@@ -1,0 +1,57 @@
+# tests/test_alu_logic.py
+import pytest
+from dspsim import FunctionalSimulator
+from dspsim.assembler import assemble
+
+def run_program(program_asm: list[str], initial_regs=None):
+    """Helper function to assemble, load, and run a program."""
+    sim = FunctionalSimulator()
+    if initial_regs:
+        for r_idx, val in initial_regs.items():
+            sim.regs[r_idx] = val
+    
+    program = assemble(program_asm)
+    sim.load_words(sim.pc, program)
+    sim.run()
+    return sim
+
+def test_and_instruction():
+    """Tests the AND instruction."""
+    sim = run_program(
+        program_asm=[
+            "AND r2, r0, r1",
+            "HALT"
+        ],
+        initial_regs={0: 0xF0F0F0F0, 1: 0x00FFFF00}
+    )
+    assert sim.regs[2] == 0x00F0F000
+
+def test_or_instruction():
+    """Tests the OR instruction."""
+    sim = run_program(
+        program_asm=[
+            "OR r2, r0, r1",
+            "HALT"
+        ],
+        initial_regs={0: 0xF0F0F0F0, 1: 0x00FFFF00}
+    )
+    assert sim.regs[2] == 0xF0FFFFF0
+
+def test_jump_forward():
+    """Tests a forward J instruction with a label."""
+    sim = run_program(
+        program_asm=[
+            "ADDI r1, r0, #100", # This executes, setting R1 to 100.
+            "J TARGET",
+            "ADDI r1, r0, #200", # This is SKIPPED by the jump.
+            "HALT",             # This is also SKIPPED.
+            "TARGET:",
+            "ADDI r2, r0, #50",  # Execution resumes here.
+            "HALT"
+        ]
+    )
+    # Corrected Assertions:
+    # 1. Check that the instruction BEFORE the jump was executed.
+    assert sim.regs[1] == 100
+    # 2. Check that the instruction AT THE TARGET was executed.
+    assert sim.regs[2] == 50


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added AND and OR instructions.
  * Added PC-relative JUMP instruction.
  * Assembler now accepts immediates with an optional leading “#”.
* Bug Fixes
  * Arithmetic and load/store address calculations now correctly wrap to 32 bits.
  * Jump encoding enforces word alignment with clearer validation errors.
* Refactor
  * Unified opcode definitions and consistent 32-bit result handling.
* Tests
  * New tests covering AND, OR, and forward jump behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->